### PR TITLE
feat: Support Inline WIF Configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -24,3 +23,37 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+.terraform.lock.hcl
+backend.conf
+
+notes

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "abusaidm.html-snippets",
     "alefragnani.project-manager",
+    "bierner.markdown-mermaid",
     "christian-kohler.path-intellisense",
     "DavidAnson.vscode-markdownlint",
     "dbaeumer.vscode-eslint",
@@ -34,6 +35,6 @@
     "VisualStudioExptTeam.vscodeintellicode",
     "yzane.markdown-pdf",
     "yzhang.markdown-all-in-one",
-    "zhuangtongfa.material-theme",
+    "zhuangtongfa.material-theme"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,59 +1,60 @@
 {
-    "workbench.colorTheme": "One Dark Pro",
-    "workbench.iconTheme": "material-icon-theme",
-    "editor.bracketPairColorization.enabled": true,
-    "editor.guides.bracketPairs": "active",
-    "workbench.editor.highlightModifiedTabs": true,
-    "editor.insertSpaces": false,
-    "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true,
-    "files.insertFinalNewline": true,
-    "editor.formatOnPaste": true,
-    "editor.formatOnSave": true,
-    "editor.tabSize": 2,
-    "editor.renderControlCharacters": true,
-    "editor.renderWhitespace": "all",
-    "[json]": {
-        "editor.defaultFormatter": "vscode.json-language-features"
-    },
-    "[jsonc]": {
-        "editor.defaultFormatter": "vscode.json-language-features"
-    },
-    "[markdown]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "[yaml]": {
-        "editor.defaultFormatter": "redhat.vscode-yaml"
-    },
-    "cSpell.words": [
-        "accesstoken",
-        "alertmanager",
-        "apimachinery",
-        "arthurvardevanyan",
-        "artifactregistry",
-        "artifactregistryv",
-        "auths",
-        "clientset",
-        "clusterrolebinding",
-        "controllerutil",
-        "corev",
-        "deepcopy",
-        "dockerconfigjson",
-        "finalizers",
-        "gomod",
-        "homelab",
-        "kubebuilder",
-        "kubeconfig",
-        "Kustomization",
-        "kustomize",
-        "metav",
-        "monitoringv",
-        "pipelinesascode",
-        "rolebinding",
-        "subresource",
-        "tekton",
-        "thanos",
-        "Tolerations",
-        "Vardevanyan"
-    ],
+  "workbench.colorTheme": "One Dark Pro",
+  "workbench.iconTheme": "material-icon-theme",
+  "editor.bracketPairColorization.enabled": true,
+  "editor.guides.bracketPairs": "active",
+  "workbench.editor.highlightModifiedTabs": true,
+  "editor.insertSpaces": false,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "editor.formatOnPaste": true,
+  "editor.formatOnSave": true,
+  "editor.tabSize": 2,
+  "editor.renderControlCharacters": true,
+  "editor.renderWhitespace": "all",
+  "[json]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  },
+  "cSpell.words": [
+    "accesstoken",
+    "alertmanager",
+    "apimachinery",
+    "arthurvardevanyan",
+    "artifactregistry",
+    "artifactregistryv",
+    "auths",
+    "clientset",
+    "clusterrolebinding",
+    "controllerutil",
+    "corev",
+    "deepcopy",
+    "dockerconfigjson",
+    "finalizers",
+    "gomod",
+    "googleapis",
+    "homelab",
+    "kubebuilder",
+    "kubeconfig",
+    "Kustomization",
+    "kustomize",
+    "metav",
+    "monitoringv",
+    "pipelinesascode",
+    "rolebinding",
+    "subresource",
+    "tekton",
+    "thanos",
+    "Tolerations",
+    "Vardevanyan"
+  ]
 }

--- a/api/v1beta1/auth_types.go
+++ b/api/v1beta1/auth_types.go
@@ -21,15 +21,31 @@ import (
 )
 
 type WifConfig struct {
-	// Object Type, must be ConfigMap
-	// +kubebuilder:validation:Enum=configMap
+	// Object Type, must be configMap or inline
+	// +kubebuilder:validation:Enum=configMap;inline
+	// +kubebuilder:validation:Required
 	Type string `json:"type"`
 	// The Name of the Kubernetes Objec Containing the Workload Identity Json Config
+	// +kubebuilder:validation:Optional
 	ObjectName string `json:"objectName"`
 	// The Name of the File Within the Object, Generally: credentials_config.json
+	// +kubebuilder:validation:Optional
 	FileName string `json:"fileName"`
 	// The Kubernetes Service Account That is Bound to a Google Service Account with Artifact Registry Reader
+	// +kubebuilder:validation:Optional
 	ServiceAccount string `json:"serviceAccount"`
+	// The Google Service Account That is to be Bound to a Kubernetes Service Account with Artifact Registry Reader
+	// +kubebuilder:validation:Optional
+	GoogleServiceAccount string `json:"googleServiceAccount"`
+	// The GCP Project in which the Workload Identity Pool/Provider is Located
+	// +kubebuilder:validation:Optional
+	GooglePoolProject string `json:"googlePoolProject"`
+	// Name of the Workload Identity Pool
+	// +kubebuilder:validation:Optional
+	GooglePoolName string `json:"googlePoolName"`
+	// Name of the Workload Identity Pool
+	// +kubebuilder:validation:Optional
+	GoogleProviderName string `json:"googleProviderName"`
 }
 
 // Contains the Fields Related to configuring GCP Workload Identity Federation

--- a/config/crd/bases/artifactregistry.arthurvardevanyan.com_auths.yaml
+++ b/config/crd/bases/artifactregistry.arthurvardevanyan.com_auths.yaml
@@ -15,118 +15,139 @@ spec:
     singular: auth
   scope: Namespaced
   versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Auth is the Schema for the auths API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Contains the Fields Related to configuring GCP Workload Identity
-              Federation
-            properties:
-              registryLocation:
-                description: Location of GCP Artifact Registry Being Used.
-                enum:
-                - us
-                - asia
-                - europe
-                - northamerica-northeast1
-                - northamerica-northeast2
-                - us-central1
-                - us-east1
-                - us-east4
-                - us-east5
-                - us-south1
-                - us-west1
-                - us-west2
-                - us-west3
-                - us-west4
-                - southamerica-east1
-                - southamerica-west1
-                - europe-central2
-                - europe-north1
-                - europe-southwest1
-                - europe-west1
-                - europe-west2
-                - europe-west3
-                - europe-west4
-                - europe-west6
-                - europe-west8
-                - europe-west9
-                - europe-west12
-                - me-central1
-                - me-west1
-                - asia-east1
-                - asia-east2
-                - asia-northeast1
-                - asia-northeast2
-                - asia-northeast3
-                - asia-south1
-                - asia-south2
-                - asia-southeast1
-                - asia-southeast2
-                - australia-southeast1
-                - australia-southeast2
-                type: string
-              secretName:
-                description: Name of the Secret to Save the Image Pull Secrt Too
-                type: string
-              wifConfig:
-                description: Contains the Fields Related to configuring GCP Workload
-                  Identity Federation
-                properties:
-                  fileName:
-                    description: 'The Name of the File Within the Object, Generally:
-                      credentials_config.json'
-                    type: string
-                  objectName:
-                    description: The Name of the Kubernetes Objec Containing the Workload
-                      Identity Json Config
-                    type: string
-                  serviceAccount:
-                    description: The Kubernetes Service Account That is Bound to a
-                      Google Service Account with Artifact Registry Reader
-                    type: string
-                  type:
-                    description: Object Type, must be ConfigMap
-                    enum:
-                    - configMap
-                    type: string
-                required:
-                - fileName
-                - objectName
-                - serviceAccount
-                - type
-                type: object
-            required:
-            - registryLocation
-            - secretName
-            - wifConfig
-            type: object
-          status:
-            description: AuthStatus defines the observed state of Auth
-            properties:
-              error:
-                description: Output of Any Errors
-                type: string
-              tokenExpiration:
-                description: When the Current Token Expires
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Auth is the Schema for the auths API
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                Contains the Fields Related to configuring GCP Workload Identity
+                Federation
+              properties:
+                registryLocation:
+                  description: Location of GCP Artifact Registry Being Used.
+                  enum:
+                    - us
+                    - asia
+                    - europe
+                    - northamerica-northeast1
+                    - northamerica-northeast2
+                    - us-central1
+                    - us-east1
+                    - us-east4
+                    - us-east5
+                    - us-south1
+                    - us-west1
+                    - us-west2
+                    - us-west3
+                    - us-west4
+                    - southamerica-east1
+                    - southamerica-west1
+                    - europe-central2
+                    - europe-north1
+                    - europe-southwest1
+                    - europe-west1
+                    - europe-west2
+                    - europe-west3
+                    - europe-west4
+                    - europe-west6
+                    - europe-west8
+                    - europe-west9
+                    - europe-west12
+                    - me-central1
+                    - me-west1
+                    - asia-east1
+                    - asia-east2
+                    - asia-northeast1
+                    - asia-northeast2
+                    - asia-northeast3
+                    - asia-south1
+                    - asia-south2
+                    - asia-southeast1
+                    - asia-southeast2
+                    - australia-southeast1
+                    - australia-southeast2
+                  type: string
+                secretName:
+                  description: Name of the Secret to Save the Image Pull Secrt Too
+                  type: string
+                wifConfig:
+                  description:
+                    Contains the Fields Related to configuring GCP Workload
+                    Identity Federation
+                  properties:
+                    fileName:
+                      description:
+                        "The Name of the File Within the Object, Generally:
+                        credentials_config.json"
+                      type: string
+                    googlePoolName:
+                      description: Name of the Workload Identity Pool
+                      type: string
+                    googlePoolProject:
+                      description:
+                        The GCP Project in which the Workload Identity Pool/Provider
+                        is Located
+                      type: string
+                    googleProviderName:
+                      description: Name of the Workload Identity Pool
+                      type: string
+                    googleServiceAccount:
+                      description:
+                        The Google Service Account That is to be Bound to
+                        a Kubernetes Service Account with Artifact Registry Reader
+                      type: string
+                    objectName:
+                      description:
+                        The Name of the Kubernetes Objec Containing the Workload
+                        Identity Json Config
+                      type: string
+                    serviceAccount:
+                      description:
+                        The Kubernetes Service Account That is Bound to a
+                        Google Service Account with Artifact Registry Reader
+                      type: string
+                    type:
+                      description: Object Type, must be configMap or inline
+                      enum:
+                        - configMap
+                        - inline
+                      type: string
+                  required:
+                    - type
+                  type: object
+              required:
+                - registryLocation
+                - secretName
+                - wifConfig
+              type: object
+            status:
+              description: AuthStatus defines the observed state of Auth
+              properties:
+                error:
+                  description: Output of Any Errors
+                  type: string
+                tokenExpiration:
+                  description: When the Current Token Expires
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:
@@ -36,6 +36,10 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      tolerations:
+        - key: node-role.kubernetes.io/infra
+          operator: Exists
+          effect: NoSchedule
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
@@ -94,9 +98,8 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 3Gi
             requests:
-              cpu: 10m
-              memory: 256Mi
+              cpu: 50m
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controllers/auth_controller.go
+++ b/controllers/auth_controller.go
@@ -115,7 +115,17 @@ func (r *AuthReconciler) Reconcile(reconcilerContext context.Context, req ctrl.R
 	//Reset Error
 	artifactRegistryAuth.Status.Error = ""
 
-	wifConfig := google.New(r.Client, artifactRegistryAuth.Namespace, artifactRegistryAuth.Spec.WifConfig.ObjectName, artifactRegistryAuth.Spec.WifConfig.FileName, artifactRegistryAuth.Spec.WifConfig.ServiceAccount)
+	wifConfig := google.New(
+		r.Client, artifactRegistryAuth.Namespace,
+		artifactRegistryAuth.Spec.WifConfig.ObjectName,
+		artifactRegistryAuth.Spec.WifConfig.FileName,
+		artifactRegistryAuth.Spec.WifConfig.ServiceAccount,
+		artifactRegistryAuth.Spec.WifConfig.GoogleServiceAccount,
+		artifactRegistryAuth.Spec.WifConfig.GooglePoolProject,
+		artifactRegistryAuth.Spec.WifConfig.GooglePoolName,
+		artifactRegistryAuth.Spec.WifConfig.GoogleProviderName,
+		artifactRegistryAuth.Spec.WifConfig.Type,
+	)
 	wifTokenSource, err := wifConfig.GetGcpWifTokenWithTokenSource(reconcilerContext)
 	if err != nil {
 		artifactRegistryAuth.Status.Error = err.Error()

--- a/sample/auth.yaml
+++ b/sample/auth.yaml
@@ -11,3 +11,19 @@ spec:
     objectName: google-wif-config
     serviceAccount: wif-test
     type: configMap
+---
+apiVersion: artifactregistry.arthurvardevanyan.com/v1beta1
+kind: Auth
+metadata:
+  name: example-inline
+  namespace: smoke-tests
+spec:
+  registryLocation: us-central1
+  secretName: artifact-registry-auth-inline
+  wifConfig:
+    serviceAccount: wif-test
+    googleServiceAccount: wif-test@afr-operator-5560235161.iam.gserviceaccount.com
+    googlePoolProject: "448527874743"
+    googlePoolName: afr-operator-pool
+    googleProviderName: afr-operator-provider
+    type: inline

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  backend "gcs" {
+    bucket = "tf-state-afr-operator-5560235161"
+    prefix = "terraform/state"
+  }
+}
+
+
+locals {
+  project = "afr-operator-5560235161"
+}
+
+
+
+resource "google_project_service" "iam" {
+  project            = local.project
+  service            = "iamcredentials.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "workload-identity-federation" {
+  project            = local.project
+  service            = "sts.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_iam_workload_identity_pool" "pool" {
+  workload_identity_pool_id = "afr-operator-pool"
+  display_name              = "afr-operator-pool"
+  description               = "Created By OpenShift ccoctl"
+  project                   = local.project
+
+  depends_on = [google_project_service.workload-identity-federation]
+}
+
+resource "google_iam_workload_identity_pool_provider" "provider" {
+  #checkov:skip=CKV_GCP_118:Allow any identity to authenticate
+  project                            = local.project
+  display_name                       = "afr-operator-provider"
+  description                        = "afr-operator-provider"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = "afr-operator-provider"
+  attribute_mapping = {
+    "google.subject" = "assertion.sub"
+  }
+  oidc {
+    issuer_uri        = "https://storage.googleapis.com/okd-homelab-wif-oidc"
+    allowed_audiences = ["openshift"]
+  }
+}
+
+resource "google_service_account" "wif_test" {
+  project      = local.project
+  account_id   = "wif-test"
+  display_name = "wif-test"
+}
+
+data "google_project" "project" {
+  project_id = local.project
+}
+
+resource "google_service_account_iam_member" "wif_test_wif_binding" {
+  service_account_id = google_service_account.wif_test.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.pool.workload_identity_pool_id}/subject/system:serviceaccount:smoke-tests:wif-test"
+}


### PR DESCRIPTION
Add Support for defining WIF Configurations inside the Custom Resource as to not need to worry about managing another object. 

```yaml
apiVersion: artifactregistry.arthurvardevanyan.com/v1beta1
kind: Auth
metadata:
  name: example
  namespace: smoke-tests
spec:
  registryLocation: us-central1
  secretName: artifact-registry-auth
  wifConfig:
    fileName: credentials_config.json
    objectName: google-wif-config
    serviceAccount: wif-test
    type: configMap

```
OR 

```yaml
apiVersion: artifactregistry.arthurvardevanyan.com/v1beta1
kind: Auth
metadata:
  name: example-inline
  namespace: smoke-tests
spec:
  registryLocation: us-central1
  secretName: artifact-registry-auth-inline
  wifConfig:
    serviceAccount: wif-test
    googleServiceAccount: wif-test@afr-operator-5560235161.iam.gserviceaccount.com
    googlePoolProject: "448527874743"
    googlePoolName: afr-operator-pool
    googleProviderName: afr-operator-provider
    type: inline
```